### PR TITLE
Added a fix for swallowing the last line in original file.

### DIFF
--- a/library/blockinfile
+++ b/library/blockinfile
@@ -211,8 +211,8 @@ def main():
     elif n0 < n1:
         lines[n0:n1+1] = []
     else:
-        lines[n1:n0+1] = []
-        n0 = n1
+        lines[n1+1:n0+1] = []
+        n0 = n1+1
 
     lines[n0:n0] = contentlines
 


### PR DESCRIPTION
This fixes the issue where the last line in the original file gets swallowed and disappears from the result file.

# Using the following ansible task
```
   - name: test blockinfile
     blockinfile:
       dest: /tmp/testfile.txt
       backup: no
       content: |
         My content
     tags: test
```

# Scenario 1:
Given test file contains endline at the end of the file.

Original file:
```
This file contains endline.

```

Result file (notice the endline is swallowed):
```
This file contains endline.
# BEGIN ANSIBLE MANAGED BLOCK
My content
# END ANSIBLE MANAGED BLOCK
```

# Scenario 2:
Given test file does not contain endline at the end of the file.

Original file:
```
This file does not contain endline.
```

Result file (the entire line disappears):
```
# BEGIN ANSIBLE MANAGED BLOCK
My content
# END ANSIBLE MANAGED BLOCK
```
